### PR TITLE
Fix upgrade issue in Deno 1.14

### DIFF
--- a/main-core/reflectMetadata.ts
+++ b/main-core/reflectMetadata.ts
@@ -91,7 +91,6 @@ export namespace Reflect {
     }
 
     type MemberDecorator = <T>(target: Object, propertyKey: string | symbol, descriptor?: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T> | void;
-    declare const Symbol: { iterator: symbol, toPrimitive: symbol };
     declare const Set: SetConstructor;
     declare const WeakMap: WeakMapConstructor;
     declare const Map: MapConstructor;


### PR DESCRIPTION
Deno 1.14 supports Typescript 4.4 which contains changes of symbol 
https://github.com/denoland/deno/releases/tag/v1.14.0
https://devblogs.microsoft.com/typescript/announcing-typescript-4-4